### PR TITLE
Added revertFilters() function in script.js

### DIFF
--- a/Image Filter App/index.html
+++ b/Image Filter App/index.html
@@ -29,7 +29,7 @@
                     <div class="row text-center mx-0 my-4" id="row-1">
                         <div class="col-md-3 col-sm-12 my-3">
                             <div class="btn-group btn-group-sm">
-                                <button class="fliter-btn brightness-remove btn btn-info">-</button>
+                                <button class="filter-btn brightness-remove btn btn-info">-</button>
                                 <button class="btn btn-secondarty btn-disabled" disabled >Brightness</button>
                                 <button class="filter-btn brightness-add btn btn-info">+</button>
                             </div>
@@ -37,7 +37,7 @@
 
                         <div class="col-md-3 col-sm-6 my-3">
                             <div class="btn-group btn-group-sm">
-                                <button class="fliter-btn contrast-remove btn btn-info">-</button>
+                                <button class="filter-btn contrast-remove btn btn-info">-</button>
                                 <button class="btn btn-secondarty btn-disabled" disabled >Contrast</button>
                                 <button class="filter-btn contrast-add btn btn-info">+</button>
                             </div>
@@ -45,7 +45,7 @@
 
                         <div class="col-md-3 col-sm-6 my-3">
                             <div class="btn-group btn-group-sm">
-                                <button class="fliter-btn saturation-remove btn btn-info">-</button>
+                                <button class="filter-btn saturation-remove btn btn-info">-</button>
                                 <button class="btn btn-secondarty btn-disabled" disabled >Saturation</button>
                                 <button class="filter-btn saturation-add btn btn-info">+</button>
                             </div>
@@ -54,7 +54,7 @@
 
                         <div class="col-md-3 col-sm-12 my-3">
                             <div class="btn-group btn-group-sm">
-                                <button class="fliter-btn vibrance-remove btn btn-info">-</button>
+                                <button class="filter-btn vibrance-remove btn btn-info">-</button>
                                 <button class="btn btn-secondarty btn-disabled" disabled >Vibrance</button>
                                 <button class="filter-btn vibrance-add btn btn-info">+</button>
                             </div>

--- a/Image Filter App/script.js
+++ b/Image Filter App/script.js
@@ -22,6 +22,7 @@ document.addEventListener("click", (e) => {
     } else if (e.target.classList.contains("contrast-add")) {
       Caman("#canvas", img, function () {
         this.contrast(5).render();
+
       });
     } else if (e.target.classList.contains("contrast-remove")) {
       Caman("#canvas", img, function () {
@@ -44,34 +45,42 @@ document.addEventListener("click", (e) => {
         this.vibrance(-5).render();
       });
     } else if (e.target.classList.contains("vintage-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.vintage().render();
       });
     } else if (e.target.classList.contains("lomo-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.lomo().render();
       });
     } else if (e.target.classList.contains("clarity-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.clarity().render();
       });
     } else if (e.target.classList.contains("sincity-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.sinCity().render();
       });
     } else if (e.target.classList.contains("crossprocess-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.crossProcess().render();
       });
     } else if (e.target.classList.contains("pinhole-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.pinhole().render();
       });
     } else if (e.target.classList.contains("nostalgia-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.nostalgia().render();
       });
     } else if (e.target.classList.contains("hermajesty-add")) {
+      revertFilters();
       Caman("#canvas", img, function () {
         this.herMajesty().render();
       });
@@ -80,10 +89,13 @@ document.addEventListener("click", (e) => {
 });
 
 // Revert Filters
+function revertFilters(updateContext = false) {
+   Caman("#canvas", img, function () {
+      this.revert(updateContext);
+   });
+}
 revertBtn.addEventListener("click", (e) => {
-  Caman("#canvas", img, function () {
-    this.revert();
-  });
+ revertFilters(true);
 });
 
 // Upload File
@@ -113,7 +125,7 @@ uploadFile.addEventListener("change", () => {
       img.onload = function () {
         canvas.width = img.width;
         canvas.height = img.height;
-        ctx.drawImage(img, 0, 0, img.width, img.height);
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
         canvas.removeAttribute("data-caman-id");
       };
     },


### PR DESCRIPTION
# Description
- revertFilters( updateContext = false) -->
- this function clears the previously applied effect of CamanJs , thereby  solving the overlap issue of other effects
- this is added to all the 8 current available effects and Remove Filters button.

Fixes #301 Bug Fix: Image Filter App (effects overlapping each other) (issue no.)

<!---give the issue number you fixed----->

## Type of change

- added function
<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->


- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
- Before Image
![before-image](https://user-images.githubusercontent.com/58480511/156936371-7151055c-c0e0-4180-b919-54cf1611fbde.png)
- After Image
![after-image](https://user-images.githubusercontent.com/58480511/156936380-933cf917-1c56-4469-9cb6-5d59cf452fd0.png)
