### PR TITLE
Fixed underweight color issue.

### DIFF
--- a/BMI-Calculator/main.js
+++ b/BMI-Calculator/main.js
@@ -13,7 +13,7 @@ function calculate() {
 
     if (bmi < 18.5) {
         category = "UnderWeight"
-        result.style.color = "#ffea00"
+        result.style.color = "#ffff00"
     }
     else if (bmi >= 18.5 && bmi <= 24.9) {
         category = "Normal Weight"

--- a/BMI-Calculator/main.js
+++ b/BMI-Calculator/main.js
@@ -13,7 +13,7 @@ function calculate() {
 
     if (bmi < 18.5) {
         category = "UnderWeight"
-        result.style.color = "ffea00"
+        result.style.color = "#ffea00"
     }
     else if (bmi >= 18.5 && bmi <= 24.9) {
         category = "Normal Weight"


### PR DESCRIPTION
# Description

For **UnderWeight** category color was supposed to use *yellow* but the code was wrong as it did not had hash before color code and the color for **underweight** and **normal weight** was same i.e. *Green*.


Fixes:  #562 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X] I have made this from my own
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings