### PR TITLE
Age Calculator presentation issue resolved

### DIFF
--- a/Age Calculator/index.html
+++ b/Age Calculator/index.html
@@ -19,17 +19,17 @@
         <p class="age">Your age is:</p>
         <div class="outputs-wrapper">
             <div>
-                <span id="years">
+                <span id="years">_</span>
                     <p>Years</p>
                 </span>
             </div>
             <div>
-                <span id="months">
+                <span id="months">_</span>
                     <p>Months</p>
                 </span>
             </div>
             <div>
-                <span id="days">
+                <span id="days">_</span>
                     <p>Days</p>
                 </span>
             </div>


### PR DESCRIPTION
# Description

As it can be seen in the screenshot that it shows only numbers after calculation in the boxes of *Years*, *Months* and *Days*. It seems odd that only numbers are written their without any unit.

Fixes:  #591 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X] I have made this from my own
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
