### PR TITLE
Age Calculator presentation issue resolved

### DIFF
--- a/Age Calculator/index.html
+++ b/Age Calculator/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div class="container">
+     <div class="container">
         <div class="inputs-wrapper">
             <input type="date" id="date-input">
             <button onclick="ageCalculate()">Calculate</button>
@@ -19,21 +19,19 @@
         <p class="age">Your age is:</p>
         <div class="outputs-wrapper">
             <div>
-                <span id="years">
-                    <p>Years</p>
-                </span>
+                <span id="years">_</span>
+                    <p>&nbsp;Years</p>
             </div>
             <div>
-                <span id="months">
-                    <p>Months</p>
-                </span>
+                <span id="months">_</span>
+                    <p>&nbsp;Months</p>
             </div>
             <div>
-                <span id="days">
-                    <p>Days</p>
-                </span>
+                <span id="days">_</span>
+                    <p>&nbsp;Days</p>
             </div>
         </div>
+    </div>
         
     <script src="script.js"></script>
     


### PR DESCRIPTION
# Description

As it can be seen in the screenshot that it shows only numbers after calculation in the boxes of *Years*, *Months* and *Days*. It seems odd that only numbers are written their without any unit. Color issue with the output is changed in #594.

Fixes:  #591 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X] I have made this from my own
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

![Screenshot 2022-05-02 170051](https://user-images.githubusercontent.com/63412921/166227084-02eebdcb-4c19-4f3c-a66e-6fab3d2946f1.jpg)