### PR TITLE
Age Calculator presentation issue resolved

### DIFF
--- a/Age Calculator/index.html
+++ b/Age Calculator/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div class="container">
+   <div class="container">
         <div class="inputs-wrapper">
             <input type="date" id="date-input">
             <button onclick="ageCalculate()">Calculate</button>
@@ -19,21 +19,19 @@
         <p class="age">Your age is:</p>
         <div class="outputs-wrapper">
             <div>
-                <span id="years">
-                    <p>Years</p>
-                </span>
+                <span id="years">_</span>
+                    <p>&nbsp;Years</p>
             </div>
             <div>
-                <span id="months">
-                    <p>Months</p>
-                </span>
+                <span id="months">_</span>
+                    <p>&nbsp;Months</p>
             </div>
             <div>
-                <span id="days">
-                    <p>Days</p>
-                </span>
+                <span id="days">_</span>
+                    <p>&nbsp;Days</p>
             </div>
         </div>
+    </div>
         
     <script src="script.js"></script>
     

--- a/Age Calculator/style.css
+++ b/Age Calculator/style.css
@@ -71,7 +71,7 @@ button {
 .outputs-wrapper {
   width: 100%;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
 }
 .outputs-wrapper div {
   height: 60px;
@@ -91,8 +91,10 @@ button {
 }
 span {
   font-family: "Poppins", sans-serif;
-  font-size: 30px;
+  color: #c5fdfff8;
+  font-size: 20px;
   font-weight: 500;
+  text-align: center;
 }
 p {
   font-family: "Ubuntu", sans-serif;


### PR DESCRIPTION
# Description

As it can be seen in the screenshot that it shows only numbers after calculation in the boxes of *Years*, *Months* and *Days*. It seems odd that only numbers are written their without any unit. It can be seen in the screenshot that it shows font size and color of output is oddly white and big.

Fixes:  #591 

<!---give the issue number you fixed----->
## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X] I have made this from my own
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

**Before changes**

![image](https://user-images.githubusercontent.com/63412921/166227351-d722b3eb-ac4f-43af-8666-e5e9f9a70ba1.png)

**After changes**

![image](https://user-images.githubusercontent.com/63412921/166227673-9ad87e4e-85a2-4f43-841b-2dcad05f125b.png)
